### PR TITLE
Chore scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Couchbase module for [Nestjs](https://github.com/nestjs/nest), built on top of
 ## Supported Couchbase version
 
 - Server version 6.x, 7.x
-- Nodejs SDK 3.x
+- Nodejs SDK 4.x (supports Couchbase SDK API 3)
 
 
 # Usage

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "prepublish": "yarn run build",
+    "prepack": "yarn run build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
## Life Cycle Scripts Use Cases

[npm official document](https://docs.npmjs.com/cli/v9/using-npm/scripts?v=true#life-cycle-operation-order) doesn't mention many use cases about life cycle scripts. 
Many projects don't use the life cycle scripts like `prepare`, `prepack`, or `prepublishOnly`, they use pipeline config file to arrange the scripts.
Some popular projects use `prepare` to build / compile, `prepublishOnly` to run lint / test, e.g. `@notionhq/client`, `minio`. 
Others suggest `prepack` to build / compile, and configure lint / test in pipeline config, e.g. [Snyk: Best practices for creating a modern npm package](https://snyk.io/blog/best-practices-create-modern-npm-package/).

Both `npm install` and `npm publish` run `prepare` script, putting `build` in `prepare` seems duplicate in the `npm install && npm publish` process.
Both `npm pack` and `npm publish` run `prepack` script, putting `build` in `prepack` makes it simpler to pack / install package to / from local.

## Summary

In this PR, `build` is in `prepack`, `prepublish` is deprecated and removed.

`npm install`, `npm lint`, `npm test` can be used for local development.

`npm install && npm publish` (will run install, build, then publish) can be used to publish to npmjs.com.